### PR TITLE
Account usage query fails with a NULL value in NAME

### DIFF
--- a/collector/query.go
+++ b/collector/query.go
@@ -28,7 +28,7 @@ const (
 	// https://docs.snowflake.com/en/sql-reference/account-usage/metering_history.html
 	creditMetricQuery = `SELECT SERVICE_TYPE, NAME, avg(CREDITS_USED_COMPUTE), avg(CREDITS_USED_CLOUD_SERVICES)
 	FROM ACCOUNT_USAGE.METERING_HISTORY
-	WHERE START_TIME >= dateadd(hour, -24, current_timestamp())
+	WHERE NAME IS NOT NULL AND START_TIME >= dateadd(hour, -24, current_timestamp())
 	GROUP BY SERVICE_TYPE, NAME;`
 
 	// https://docs.snowflake.com/en/sql-reference/account-usage/warehouse_metering_history.html


### PR DESCRIPTION
The credit metrics query fails when the value in the NAME column is NULL with the following error:
    
`failed to scan row: sql: Scan error on column index 1, name \"NAME\": converting NULL to string is unsupported
`    

So we're filtering rows with NAME at NULL