### PR TITLE
feat: Support RSA private key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,35 @@ Exports [Snowflake](www.snowflake.com) warehouse, database, table, and replicati
 ### Command line flags
 The exporter may be configured through its command line flags:
 ```
-  -h, --help                 Show context-sensitive help (also try --help-long and --help-man).
+  -h, --help                                 Show context-sensitive help (also try --help-long and --help-man).
       --web.listen-address=:9975 ...  
-                             Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.
-      --web.config.file=""   [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
+                                             Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.
+      --web.config.file=""                   [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
       --web.telemetry-path="/metrics"  
-                             Path under which to expose metrics.
-      --account=ACCOUNT      The account to collect metrics for.
-      --username=USERNAME    The username for the user used when querying metrics.
-      --password=PASSWORD    The password for the user used when querying metrics.
-      --role="ACCOUNTADMIN"  The role to use when querying metrics.
-      --warehouse=WAREHOUSE  The warehouse to use when querying metrics.
-      --version              Show application version.
-      --log.level=info       Only log messages with the given severity or above. One of: [debug, info, warn, error]
-      --log.format=logfmt    Output format of log messages. One of: [logfmt, json]
+                                             Path under which to expose metrics.
+      --account=ACCOUNT                      The account to collect metrics for.
+      --username=USERNAME                    The username for the user used when querying metrics.
+      --password=PASSWORD                    The password for the user used when querying metrics.
+      --private-key-path=./PRIVATE_KEY.p8  
+                                             The path to the private key (PKCS #8 syntax).
+      --role="ACCOUNTADMIN"                  The role to use when querying metrics.
+      --warehouse=WAREHOUSE                  The warehouse to use when querying metrics.
+      --version                              Show application version.
+      --log.level=info                       Only log messages with the given severity or above. One of: [debug, info, warn, error]
+      --log.format=logfmt                    Output format of log messages. One of: [logfmt, json]
 ```
 
-Example usage: 
+Example usage (with password): 
 ```sh
 ./snowflake-exporter --account=XXXXXXX-YYYYYYY --username=USERNAME --password=PASSWORD --warehouse=WAREHOUSE --role=ACCOUNTADMIN
 ```
+
+Example usage (with private key): 
+```sh
+./snowflake-exporter --account=XXXXXXX-YYYYYYY --username=USERNAME --private-key-path=./PRIVATE_KEY.p8 --warehouse=WAREHOUSE --role=ACCOUNTADMIN
+```
+
+_If both password and private key file are specified, the private key takes precedence._
 
 ### Environment Variables
 Alternatively, the exporter may be configured using environment variables:
@@ -35,15 +44,26 @@ Alternatively, the exporter may be configured using environment variables:
 | SNOWFLAKE_EXPORTER_ACCOUNT            | The account to collect metrics for.                   |
 | SNOWFLAKE_EXPORTER_USERNAME           | The username for the user used when querying metrics. |
 | SNOWFLAKE_EXPORTER_PASSWORD           | The password for the user used when querying metrics. |
+| SNOWFLAKE_EXPORTER_PRIVATE_KEY_PATH   | The path to the private key (PKCS #8 syntax).         |
 | SNOWFLAKE_EXPORTER_ROLE               | The role to use when querying metrics.                |
 | SNOWFLAKE_EXPORTER_WAREHOUSE          | The warehouse to use when querying metrics.           |
 | SNOWFLAKE_EXPORTER_WEB_TELEMETRY_PATH | Path under which to expose metrics.                   |
 
-Example usage:
+Example usage (with password):
 ```sh
 SNOWFLAKE_EXPORTER_ACCOUNT=XXXXXXX-YYYYYYY \
 SNOWFLAKE_EXPORTER_USERNAME=USERNAME \
 SNOWFLAKE_EXPORTER_PASSWORD=PASSWORD \
+SNOWFLAKE_EXPORTER_ROLE=ACCOUNTADMIN \
+SNOWFLAKE_EXPORTER_WAREHOUSE=WAREHOUSE \
+./snowflake-exporter
+```
+
+Example usage (with private key):
+```sh
+SNOWFLAKE_EXPORTER_ACCOUNT=XXXXXXX-YYYYYYY \
+SNOWFLAKE_EXPORTER_USERNAME=USERNAME \
+SNOWFLAKE_EXPORTER_PRIVATE_KEY_PATH=./PRIVATE_KEY.p8 \
 SNOWFLAKE_EXPORTER_ROLE=ACCOUNTADMIN \
 SNOWFLAKE_EXPORTER_WAREHOUSE=WAREHOUSE \
 ./snowflake-exporter

--- a/cmd/snowflake-exporter/main.go
+++ b/cmd/snowflake-exporter/main.go
@@ -33,13 +33,14 @@ import (
 )
 
 var (
-	webConfig  = webflag.AddFlags(kingpin.CommandLine, ":9975")
-	metricPath = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").Envar("SNOWFLAKE_EXPORTER_WEB_TELEMETRY_PATH").String()
-	account    = kingpin.Flag("account", "The account to collect metrics for.").Envar("SNOWFLAKE_EXPORTER_ACCOUNT").Required().String()
-	username   = kingpin.Flag("username", "The username for the user used when querying metrics.").Envar("SNOWFLAKE_EXPORTER_USERNAME").Required().String()
-	password   = kingpin.Flag("password", "The password for the user used when querying metrics.").Envar("SNOWFLAKE_EXPORTER_PASSWORD").Required().String()
-	role       = kingpin.Flag("role", "The role to use when querying metrics.").Default("ACCOUNTADMIN").Envar("SNOWFLAKE_EXPORTER_ROLE").String()
-	warehouse  = kingpin.Flag("warehouse", "The warehouse to use when querying metrics.").Envar("SNOWFLAKE_EXPORTER_WAREHOUSE").Required().String()
+	webConfig          = webflag.AddFlags(kingpin.CommandLine, ":9975")
+	metricPath         = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").Envar("SNOWFLAKE_EXPORTER_WEB_TELEMETRY_PATH").String()
+	account            = kingpin.Flag("account", "The account to collect metrics for.").Envar("SNOWFLAKE_EXPORTER_ACCOUNT").Required().String()
+	username           = kingpin.Flag("username", "The username for the user used when querying metrics.").Envar("SNOWFLAKE_EXPORTER_USERNAME").Required().String()
+	password           = kingpin.Flag("password", "The password for the user used when querying metrics.").Envar("SNOWFLAKE_EXPORTER_PASSWORD").String()
+	role               = kingpin.Flag("role", "The role to use when querying metrics.").Default("ACCOUNTADMIN").Envar("SNOWFLAKE_EXPORTER_ROLE").String()
+	warehouse          = kingpin.Flag("warehouse", "The warehouse to use when querying metrics.").Envar("SNOWFLAKE_EXPORTER_WAREHOUSE").Required().String()
+	privateKeyFilePath = kingpin.Flag("private-key-path", "The path to the private key (PKCS #8 syntax).").Envar("SNOWFLAKE_EXPORTER_PRIVATE_KEY_PATH").String()
 )
 
 const (
@@ -67,11 +68,12 @@ func main() {
 
 	// Construct the collector, using the flags for configuration
 	c := &collector.Config{
-		AccountName: *account,
-		Username:    *username,
-		Password:    *password,
-		Role:        *role,
-		Warehouse:   *warehouse,
+		AccountName:        *account,
+		Username:           *username,
+		Password:           *password,
+		Role:               *role,
+		Warehouse:          *warehouse,
+		PrivateKeyFilePath: *privateKeyFilePath,
 	}
 
 	if err := c.Validate(); err != nil {

--- a/collector/config_test.go
+++ b/collector/config_test.go
@@ -47,14 +47,14 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: errNoUsername,
 		},
 		{
-			name: "No password",
+			name: "No password and no private key",
 			inputConfig: Config{
 				AccountName: "some_account",
 				Username:    "some_user",
 				Role:        "ACCOUNTADMIN",
 				Warehouse:   "ACCOUNT_WH",
 			},
-			expectedErr: errNoPassword,
+			expectedErr: errNoPasswordAndNoPrivateKey,
 		},
 		{
 			name: "No Role",
@@ -77,13 +77,23 @@ func TestConfig_Validate(t *testing.T) {
 			expectedErr: errNoWarehouse,
 		},
 		{
-			name: "Valid config",
+			name: "Valid config with password",
 			inputConfig: Config{
 				AccountName: "some_account",
 				Username:    "some_user",
 				Password:    "some_pass",
 				Role:        "ACCOUNTADMIN",
 				Warehouse:   "ACCOUNT_WH",
+			},
+		},
+		{
+			name: "Valid config with private key",
+			inputConfig: Config{
+				AccountName:        "some_account",
+				Username:           "some_user",
+				PrivateKeyFilePath: "./some_private_key.p8",
+				Role:               "ACCOUNTADMIN",
+				Warehouse:          "ACCOUNT_WH",
 			},
 		},
 	}
@@ -115,7 +125,7 @@ func TestConfig_snowflakeConnectionString(t *testing.T) {
 				Role:        "ACCOUNTADMIN",
 				Warehouse:   "some-warehouse",
 			},
-			expectedString: "some-user:some-pass@some-account/SNOWFLAKE?role=ACCOUNTADMIN&warehouse=some-warehouse",
+			expectedString: "some-user:some-pass@some-account.snowflakecomputing.com:443?database=SNOWFLAKE&ocspFailOpen=true&role=ACCOUNTADMIN&validateDefaultParameters=true&warehouse=some-warehouse",
 		},
 		{
 			name: "Connection string parts are escaped",
@@ -126,7 +136,7 @@ func TestConfig_snowflakeConnectionString(t *testing.T) {
 				Role:        "ACCOUNTADMIN!",
 				Warehouse:   "some!warehouse",
 			},
-			expectedString: `some%25user:some+pass@some%25account/SNOWFLAKE?role=ACCOUNTADMIN%21&warehouse=some%21warehouse`,
+			expectedString: "some%25user:some+pass@some%account.snowflakecomputing.com:443?database=SNOWFLAKE&ocspFailOpen=true&role=ACCOUNTADMIN%21&validateDefaultParameters=true&warehouse=some%21warehouse",
 		},
 	}
 

--- a/collector/testdata/all_metrics.prom
+++ b/collector/testdata/all_metrics.prom
@@ -71,19 +71,19 @@ snowflake_used_cloud_services_credits{service="mock_service_type",service_type="
 # TYPE snowflake_used_compute_credits gauge
 snowflake_used_compute_credits{service="another_mock_service_type",service_type="another_mock_service"} 0.25
 snowflake_used_compute_credits{service="mock_service_type",service_type="mock_service"} 0.5
-# HELP snowflake_warehouse_blocked_queries Average number of queries blocked by a transaction lock.
+# HELP snowflake_warehouse_blocked_queries Average load value for queries blocked by a transaction lock over the last 24 hours.
 # TYPE snowflake_warehouse_blocked_queries gauge
 snowflake_warehouse_blocked_queries{id="10",name="mock_warehouse"} 10
 snowflake_warehouse_blocked_queries{id="11",name="another_mock_warehouse"} 534
-# HELP snowflake_warehouse_executed_queries Average number of queries executed.
+# HELP snowflake_warehouse_executed_queries Average query load for queries executed over the last 24 hours.
 # TYPE snowflake_warehouse_executed_queries gauge
 snowflake_warehouse_executed_queries{id="10",name="mock_warehouse"} 80
 snowflake_warehouse_executed_queries{id="11",name="another_mock_warehouse"} 1234
-# HELP snowflake_warehouse_overloaded_queue_size Average number of queries queued because the warehouse was overloaded.
+# HELP snowflake_warehouse_overloaded_queue_size Average load value for queries queued because the warehouse was being overloaded over the last 24 hours.
 # TYPE snowflake_warehouse_overloaded_queue_size gauge
 snowflake_warehouse_overloaded_queue_size{id="10",name="mock_warehouse"} 40
 snowflake_warehouse_overloaded_queue_size{id="11",name="another_mock_warehouse"} 123
-# HELP snowflake_warehouse_provisioning_queue_size Average number of queries queued because the warehouse was being provisioned.
+# HELP snowflake_warehouse_provisioning_queue_size Average load value for queries queued because the warehouse was being provisioned over the last 24 hours.
 # TYPE snowflake_warehouse_provisioning_queue_size gauge
 snowflake_warehouse_provisioning_queue_size{id="10",name="mock_warehouse"} 20
 snowflake_warehouse_provisioning_queue_size{id="11",name="another_mock_warehouse"} 234


### PR DESCRIPTION
This PR adds support for private key authentication:  https://docs.snowflake.com/en/user-guide/key-pair-auth

Snowflake's Go driver's private key documentation: https://github.com/snowflakedb/gosnowflake/blob/c355711dbd1f9ab10dfbfdcdd194656c23abb45d/doc.go#L793-L800

To support private keys, we use the official [Snowflake DSN `Config`](https://github.com/snowflakedb/gosnowflake/blob/c355711dbd1f9ab10dfbfdcdd194656c23abb45d/dsn.go#L44) from the Go driver

This allows us to craft a DSN using the official [`DSN(cfg *Config)` function ](https://github.com/snowflakedb/gosnowflake/blob/c355711dbd1f9ab10dfbfdcdd194656c23abb45d/dsn.go#L135)

*Ideally, when using a private key, password is not set.  However, if password is set, the private key will still be used, rendering the password irrelevant.

*If both password and private key are not provided, an error is raised.

---

Go test:
```
❯ make test
>> running all tests
go test -race  ./...
?       github.com/grafana/snowflake-prometheus-exporter/cmd/snowflake-exporter [no test files]
ok      github.com/grafana/snowflake-prometheus-exporter/collector      1.079s
```

also resolves #6 

---

What if password is set and private key path is not?
* The auth will be username:password, same as before.

What if private key path is set and password is not?
* The authenticator will be `AuthTypeJwt` and the private key will be used.

What if both password and private key path are specified?
* The private key takes precedence:  the authenticator will be set to `AuthTypeJwt` and the private key will be used.