### PR TITLE
feat: Metric collection with goroutines

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -18,7 +18,6 @@ import (
 	"database/sql"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -414,7 +413,6 @@ func (c *Collector) collectStorageMetrics(db *sql.DB, metrics chan<- prometheus.
 		metrics <- prometheus.MustNewConstMetric(c.failsafeBytes, prometheus.GaugeValue, failsafeBytes.Float64)
 	}
 
-	// TODO: remove after testing
 	return rows.Err()
 }
 
@@ -440,8 +438,6 @@ func (c *Collector) collectDatabaseStorageMetrics(db *sql.DB, metrics chan<- pro
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -467,8 +463,6 @@ func (c *Collector) collectCreditMetrics(db *sql.DB, metrics chan<- prometheus.M
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -494,8 +488,6 @@ func (c *Collector) collectWarehouseCreditMetrics(db *sql.DB, metrics chan<- pro
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -525,8 +517,6 @@ func (c *Collector) collectLoginMetrics(db *sql.DB, metrics chan<- prometheus.Me
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -558,8 +548,6 @@ func (c *Collector) collectWarehouseLoadMetrics(db *sql.DB, metrics chan<- prome
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -592,8 +580,6 @@ func (c *Collector) collectAutoClusteringMetrics(db *sql.DB, metrics chan<- prom
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -630,8 +616,6 @@ func (c *Collector) collectTableStorageMetrics(db *sql.DB, metrics chan<- promet
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(60 * time.Second)
 	return rows.Err()
 }
 
@@ -657,7 +641,5 @@ func (c *Collector) collectReplicationMetrics(db *sql.DB, metrics chan<- prometh
 		}
 	}
 
-	// TODO: remove after testing
-	time.Sleep(10 * time.Second)
 	return rows.Err()
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -286,9 +286,8 @@ func (c *Collector) Describe(descs chan<- *prometheus.Desc) {
 func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 	level.Debug(c.logger).Log("msg", "Collecting metrics.")
 
-	// Create a WaitGroup to block closing the DB until all 9 goroutines are done
+	// Create a WaitGroup to block closing the database until all goroutines are done
 	var wg sync.WaitGroup
-	wg.Add(9)
 
 	var up float64 = 1
 	// Open a new connection to the database each time; This makes the connection more robust to transient failures
@@ -308,6 +307,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 	}
 	defer db.Close()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectStorageMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect storage metrics.", "err", err)
@@ -316,6 +316,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectDatabaseStorageMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect database storage metrics.", "err", err)
@@ -324,6 +325,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectCreditMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect credit metrics.", "err", err)
@@ -332,6 +334,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectWarehouseCreditMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect warehouse credit metrics.", "err", err)
@@ -340,6 +343,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectLoginMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect login metrics.", "err", err)
@@ -348,6 +352,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectWarehouseLoadMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect warehouse load metrics.", "err", err)
@@ -356,6 +361,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectAutoClusteringMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect autoclustering metrics.", "err", err)
@@ -364,6 +370,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectTableStorageMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect table storage metrics.", "err", err)
@@ -372,6 +379,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
+	wg.Add(1)
 	go func() {
 		if err := c.collectReplicationMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect replication metrics.", "err", err)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -380,6 +381,8 @@ func (c *Collector) collectStorageMetrics(db *sql.DB, metrics chan<- prometheus.
 		metrics <- prometheus.MustNewConstMetric(c.failsafeBytes, prometheus.GaugeValue, failsafeBytes.Float64)
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -405,6 +408,8 @@ func (c *Collector) collectDatabaseStorageMetrics(db *sql.DB, metrics chan<- pro
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -430,6 +435,8 @@ func (c *Collector) collectCreditMetrics(db *sql.DB, metrics chan<- prometheus.M
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -455,6 +462,8 @@ func (c *Collector) collectWarehouseCreditMetrics(db *sql.DB, metrics chan<- pro
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -484,6 +493,8 @@ func (c *Collector) collectLoginMetrics(db *sql.DB, metrics chan<- prometheus.Me
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -515,6 +526,8 @@ func (c *Collector) collectWarehouseLoadMetrics(db *sql.DB, metrics chan<- prome
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -547,6 +560,8 @@ func (c *Collector) collectAutoClusteringMetrics(db *sql.DB, metrics chan<- prom
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }
 
@@ -583,6 +598,8 @@ func (c *Collector) collectTableStorageMetrics(db *sql.DB, metrics chan<- promet
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(60 * time.Second)
 	return rows.Err()
 }
 
@@ -608,5 +625,7 @@ func (c *Collector) collectReplicationMetrics(db *sql.DB, metrics chan<- prometh
 		}
 	}
 
+	// TODO: remove after testing
+	time.Sleep(10 * time.Second)
 	return rows.Err()
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -42,6 +42,7 @@ var ExampleConfig = &Config{
 func TestCollector_Collect(t *testing.T) {
 	t.Run("Metrics match expected", func(t *testing.T) {
 		db, mock := createMockDB(t)
+		mock.MatchExpectationsInOrder(false)
 
 		col := NewCollector(log.NewJSONLogger(os.Stdout), ExampleConfig)
 		col.openDatabase = func(_ string) (*sql.DB, error) { return db, nil }
@@ -57,6 +58,7 @@ func TestCollector_Collect(t *testing.T) {
 
 	t.Run("Metrics have no lint errors", func(t *testing.T) {
 		db, mock := createMockDB(t)
+		mock.MatchExpectationsInOrder(false)
 
 		col := NewCollector(log.NewJSONLogger(os.Stdout), ExampleConfig)
 		col.openDatabase = func(_ string) (*sql.DB, error) { return db, nil }
@@ -70,6 +72,7 @@ func TestCollector_Collect(t *testing.T) {
 
 	t.Run("All queries fail", func(t *testing.T) {
 		db, mock := createQueryErrMockDB(t)
+		mock.MatchExpectationsInOrder(false)
 
 		col := NewCollector(log.NewJSONLogger(os.Stdout), ExampleConfig)
 		col.openDatabase = func(_ string) (*sql.DB, error) { return db, nil }


### PR DESCRIPTION
## About this PR
In large Snowflake environments, high collection times led to scrapes timing out. This PR implements goroutines to speed up metric collection time.

**Related Issue**
[#10637](https://github.com/grafana/support-escalations/issues/10637)