### PR TITLE
feat: Add debug logs to metric collection

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -396,6 +396,7 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 func (c *Collector) collectStorageMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting storage metrics.")
 	rows, err := db.Query(storageMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying storage metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -430,6 +431,7 @@ func (c *Collector) collectStorageMetrics(db *sql.DB, metrics chan<- prometheus.
 func (c *Collector) collectDatabaseStorageMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting database storage metrics.")
 	rows, err := db.Query(databaseStorageMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying database storage metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -457,6 +459,7 @@ func (c *Collector) collectDatabaseStorageMetrics(db *sql.DB, metrics chan<- pro
 func (c *Collector) collectCreditMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting credit metrics.")
 	rows, err := db.Query(creditMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying credit metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -484,6 +487,7 @@ func (c *Collector) collectCreditMetrics(db *sql.DB, metrics chan<- prometheus.M
 func (c *Collector) collectWarehouseCreditMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting warehouse credit metrics.")
 	rows, err := db.Query(warehouseCreditMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying warehouse credit metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -511,6 +515,7 @@ func (c *Collector) collectWarehouseCreditMetrics(db *sql.DB, metrics chan<- pro
 func (c *Collector) collectLoginMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting login metrics.")
 	rows, err := db.Query(loginMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying login metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -542,6 +547,7 @@ func (c *Collector) collectLoginMetrics(db *sql.DB, metrics chan<- prometheus.Me
 func (c *Collector) collectWarehouseLoadMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting warehouse load metrics.")
 	rows, err := db.Query(warehouseLoadMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying warehouse load metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -575,6 +581,7 @@ func (c *Collector) collectWarehouseLoadMetrics(db *sql.DB, metrics chan<- prome
 func (c *Collector) collectAutoClusteringMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting auto-clustering metrics.")
 	rows, err := db.Query(autoClusteringMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying auto-clustering metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -609,6 +616,7 @@ func (c *Collector) collectAutoClusteringMetrics(db *sql.DB, metrics chan<- prom
 func (c *Collector) collectTableStorageMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting table storage metrics.")
 	rows, err := db.Query(tableStorageMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying table storage metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}
@@ -647,6 +655,7 @@ func (c *Collector) collectTableStorageMetrics(db *sql.DB, metrics chan<- promet
 func (c *Collector) collectReplicationMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
 	level.Debug(c.logger).Log("msg", "Collecting replication metrics.")
 	rows, err := db.Query(replicationMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying replication metrics.")
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -390,9 +390,11 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 
 	wg.Wait()
 	metrics <- prometheus.MustNewConstMetric(c.up, prometheus.GaugeValue, up)
+	level.Debug(c.logger).Log("msg", "Finished collecting metrics.")
 }
 
 func (c *Collector) collectStorageMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting storage metrics.")
 	rows, err := db.Query(storageMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -421,10 +423,12 @@ func (c *Collector) collectStorageMetrics(db *sql.DB, metrics chan<- prometheus.
 		metrics <- prometheus.MustNewConstMetric(c.failsafeBytes, prometheus.GaugeValue, failsafeBytes.Float64)
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting storage metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectDatabaseStorageMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting database storage metrics.")
 	rows, err := db.Query(databaseStorageMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -446,10 +450,12 @@ func (c *Collector) collectDatabaseStorageMetrics(db *sql.DB, metrics chan<- pro
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting database storage metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectCreditMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting credit metrics.")
 	rows, err := db.Query(creditMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -471,10 +477,12 @@ func (c *Collector) collectCreditMetrics(db *sql.DB, metrics chan<- prometheus.M
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting credit metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectWarehouseCreditMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting warehouse credit metrics.")
 	rows, err := db.Query(warehouseCreditMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -496,10 +504,12 @@ func (c *Collector) collectWarehouseCreditMetrics(db *sql.DB, metrics chan<- pro
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting warehouse credit metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectLoginMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting login metrics.")
 	rows, err := db.Query(loginMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -525,10 +535,12 @@ func (c *Collector) collectLoginMetrics(db *sql.DB, metrics chan<- prometheus.Me
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting login metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectWarehouseLoadMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting warehouse load metrics.")
 	rows, err := db.Query(warehouseLoadMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -556,10 +568,12 @@ func (c *Collector) collectWarehouseLoadMetrics(db *sql.DB, metrics chan<- prome
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting warehouse load metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectAutoClusteringMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting auto-clustering metrics.")
 	rows, err := db.Query(autoClusteringMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -588,10 +602,12 @@ func (c *Collector) collectAutoClusteringMetrics(db *sql.DB, metrics chan<- prom
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting auto-clustering metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectTableStorageMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting table storage metrics.")
 	rows, err := db.Query(tableStorageMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -624,10 +640,12 @@ func (c *Collector) collectTableStorageMetrics(db *sql.DB, metrics chan<- promet
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting table storage metrics.")
 	return rows.Err()
 }
 
 func (c *Collector) collectReplicationMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting replication metrics.")
 	rows, err := db.Query(replicationMetricQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query metrics: %w", err)
@@ -649,5 +667,6 @@ func (c *Collector) collectReplicationMetrics(db *sql.DB, metrics chan<- prometh
 		}
 	}
 
+	level.Debug(c.logger).Log("msg", "Finished collecting replication metrics.")
 	return rows.Err()
 }


### PR DESCRIPTION
This PR adds additional debug logs to the exporter to assist in debugging sticking points for metric collection.

![image](https://github.com/user-attachments/assets/7d469165-075f-4a73-8ad6-6538bbf6050a)
