### PR TITLE
feat: Add deleted_tables metric (INT1-100)

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -78,6 +78,7 @@ type Collector struct {
 	tableTimeTravelBytes              *prometheus.Desc
 	tableFailsafeBytes                *prometheus.Desc
 	tableCloneBytes                   *prometheus.Desc
+	tableDeletedTables                *prometheus.Desc
 	replicationUsedCredits            *prometheus.Desc
 	replicationTransferredBytes       *prometheus.Desc
 	up                                *prometheus.Desc
@@ -228,6 +229,12 @@ func NewCollector(logger log.Logger, c *Config) *Collector {
 			[]string{labelTableName, labelTableID, labelSchemaName, labelSchemaID, labelDatabaseName, labelDatabaseID},
 			nil,
 		),
+		tableDeletedTables: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "table", "deleted_tables"),
+			"Number of tables that have been purged from storage.",
+			nil,
+			nil,
+		),
 		replicationUsedCredits: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "db_replication", "used_credits"),
 			"Sum of the number of credits used for database replication over the last 24 hours.",
@@ -276,6 +283,7 @@ func (c *Collector) Describe(descs chan<- *prometheus.Desc) {
 	descs <- c.tableTimeTravelBytes
 	descs <- c.tableFailsafeBytes
 	descs <- c.tableCloneBytes
+	descs <- c.tableDeletedTables
 	descs <- c.replicationUsedCredits
 	descs <- c.replicationTransferredBytes
 	descs <- c.up
@@ -374,6 +382,15 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 	go func() {
 		if err := c.collectTableStorageMetrics(db, metrics); err != nil {
 			level.Error(c.logger).Log("msg", "Failed to collect table storage metrics.", "err", err)
+			up = 0
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		if err := c.collectDeletedTablesMetrics(db, metrics); err != nil {
+			level.Error(c.logger).Log("msg", "Failed to collect deleted tables metrics.", "err", err)
 			up = 0
 		}
 		wg.Done()
@@ -621,6 +638,29 @@ func (c *Collector) collectTableStorageMetrics(db *sql.DB, metrics chan<- promet
 		if cloneBytes.Valid {
 			metrics <- prometheus.MustNewConstMetric(c.tableCloneBytes, prometheus.GaugeValue, cloneBytes.Float64,
 				tableName.String, tableID.String, schemaName.String, schemaID.String, databaseName.String, databaseID.String)
+		}
+	}
+
+	return rows.Err()
+}
+
+func (c *Collector) collectDeletedTablesMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	level.Debug(c.logger).Log("msg", "Collecting deleted table metrics.")
+	rows, err := db.Query(deletedTablesMetricQuery)
+	level.Debug(c.logger).Log("msg", "Done querying deleted table metrics.")
+	if err != nil {
+		return fmt.Errorf("failed to query metrics: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var deletedTables sql.NullFloat64
+		if err := rows.Scan(&deletedTables); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if deletedTables.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.tableDeletedTables, prometheus.GaugeValue, deletedTables.Float64)
 		}
 	}
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -351,6 +351,16 @@ func createMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 		).
 		RowsWillBeClosed()
 
+	mock.ExpectQuery(deletedTablesMetricQuery).
+		WillReturnRows(
+			newRows(t, [][]*string{
+				{
+					&val19,
+				},
+			}),
+		).
+		RowsWillBeClosed()
+
 	mock.ExpectQuery(replicationMetricQuery).
 		WillReturnRows(
 			newRows(t, [][]*string{
@@ -387,6 +397,7 @@ func createQueryErrMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 	mock.ExpectQuery(warehouseLoadMetricQuery).WillReturnError(queryErr)
 	mock.ExpectQuery(autoClusteringMetricQuery).WillReturnError(queryErr)
 	mock.ExpectQuery(tableStorageMetricQuery).WillReturnError(queryErr)
+	mock.ExpectQuery(deletedTablesMetricQuery).WillReturnError(queryErr)
 	mock.ExpectQuery(replicationMetricQuery).WillReturnError(queryErr)
 
 	mock.ExpectClose()

--- a/collector/query.go
+++ b/collector/query.go
@@ -63,6 +63,11 @@ const (
 	FROM ACCOUNT_USAGE.TABLE_STORAGE_METRICS
 	GROUP BY TABLE_NAME, ID, TABLE_CATALOG, TABLE_CATALOG_ID, TABLE_SCHEMA, TABLE_SCHEMA_ID;`
 
+	// https://docs.snowflake.com/en/sql-reference/account-usage/table_storage_metrics
+	deletedTablesMetricQuery = `SELECT COUNT(DISTINCT TABLE_NAME, ID, TABLE_SCHEMA, TABLE_SCHEMA_ID, TABLE_CATALOG, TABLE_CATALOG_ID) AS NUM_TABLES
+	FROM ACCOUNT_USAGE.TABLE_STORAGE_METRICS
+	WHERE DELETED = TRUE;`
+
 	// https://docs.snowflake.com/en/sql-reference/account-usage/replication_usage_history.html
 	replicationMetricQuery = `SELECT DATABASE_NAME, DATABASE_ID, sum(CREDITS_USED), sum(BYTES_TRANSFERRED) 
 	FROM ACCOUNT_USAGE.REPLICATION_USAGE_HISTORY

--- a/collector/testdata/all_metrics.prom
+++ b/collector/testdata/all_metrics.prom
@@ -63,6 +63,9 @@ snowflake_table_failsafe_bytes{database_id="2",database_name="another_mock_db",s
 # TYPE snowflake_table_time_travel_bytes gauge
 snowflake_table_time_travel_bytes{database_id="1",database_name="mock_db",schema_id="4",schema_name="mock_schema",table_id="3",table_name="mock_table"} 2048
 snowflake_table_time_travel_bytes{database_id="2",database_name="another_mock_db",schema_id="4",schema_name="",table_id="3",table_name="mock_table"} 32768
+# HELP snowflake_table_deleted_tables Number of tables that have been purged from storage.
+# TYPE snowflake_table_deleted_tables gauge
+snowflake_table_deleted_tables 10
 # HELP snowflake_used_cloud_services_credits Average overall credits billed per hour for cloud services over the last 24 hours.
 # TYPE snowflake_used_cloud_services_credits gauge
 snowflake_used_cloud_services_credits{service="another_mock_service_type",service_type="another_mock_service"} 0.125


### PR DESCRIPTION
## Changes
This PR adds a metric to track deleted tables that may be persisting and negatively impacting table storage query performance.

### Example curl output:
```
# HELP snowflake_table_deleted_tables Number of tables that have been purged from storage.
# TYPE snowflake_table_deleted_tables gauge
snowflake_table_deleted_tables 216
```

**Related Issue:** [#10637](https://github.com/grafana/support-escalations/issues/10637)