### PR TITLE
feat: Update default table storage query (INT1-106)

### DIFF
--- a/collector/query.go
+++ b/collector/query.go
@@ -58,9 +58,10 @@ const (
 	GROUP BY TABLE_NAME, TABLE_ID, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID;`
 
 	// https://docs.snowflake.com/en/sql-reference/account-usage/table_storage_metrics.html
-	tableStorageMetricQuery = `SELECT TABLE_NAME, ID, TABLE_SCHEMA, TABLE_SCHEMA_ID, TABLE_CATALOG, TABLE_CATALOG_ID, 
+	tableStorageMetricQuery = `SELECT TABLE_NAME, ID, TABLE_SCHEMA, TABLE_SCHEMA_ID, TABLE_CATALOG, TABLE_CATALOG_ID,
 		sum(ACTIVE_BYTES), sum(TIME_TRAVEL_BYTES), sum(FAILSAFE_BYTES), sum(RETAINED_FOR_CLONE_BYTES)
 	FROM ACCOUNT_USAGE.TABLE_STORAGE_METRICS
+	WHERE TABLE_ENTERED_FAILSAFE IS NULL OR TABLE_ENTERED_FAILSAFE >= dateadd(day, -8, current_timestamp())
 	GROUP BY TABLE_NAME, ID, TABLE_CATALOG, TABLE_CATALOG_ID, TABLE_SCHEMA, TABLE_SCHEMA_ID;`
 
 	// https://docs.snowflake.com/en/sql-reference/account-usage/replication_usage_history.html


### PR DESCRIPTION
## Changes
This PR modifies the basic table storage metrics query to only grab tables that are active or have entered failsafe in the last 8 days. Tables in failsafe for longer than 7 days are historical records that cannot be restored but will persist indefinitely. This is part of an effort to reduce the amount of data returned by this query to improve exporter performance.

**Related Issue:** [#10637](https://github.com/grafana/support-escalations/issues/10637)


Performance results of timed curl request with new/old queries:

```
New:
1.  8.463s
2.  5.909s
3.  5.180s
4.  5.092s
5.  5.058s

avg: 5.9404
avg (w/o 1st): 5.30875

Old:
1. 4.695s
2. 4.469s
3. 4.690s
4. 4.467s
5. 5.325s

avg: 4.7292

25.6% average increase
12.3% avg increase w/o outlier
```