### PR TITLE
Disable collectDeletedTablesMetrics when config.ExcludeDeleted is true

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -387,14 +387,16 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
-	wg.Add(1)
-	go func() {
-		if err := c.collectDeletedTablesMetrics(db, metrics); err != nil {
-			level.Error(c.logger).Log("msg", "Failed to collect deleted tables metrics.", "err", err)
-			up = 0
-		}
-		wg.Done()
-	}()
+	if !c.config.ExcludeDeleted {
+		wg.Add(1)
+		go func() {
+			if err := c.collectDeletedTablesMetrics(db, metrics); err != nil {
+				level.Error(c.logger).Log("msg", "Failed to collect deleted tables metrics.", "err", err)
+				up = 0
+			}
+			wg.Done()
+		}()
+	}
 
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
Hi Grafana team!

We recently set this up via alloy and were surprised to find that the
`collectDeletedTablesMetrics` wasn't disabled when
`config.ExcludeDeleted` was set to true. The query in question takes
north of 20 minutes to execute for us, and we'd like to disable it if
possible.

Happy to make changes if the reviewer would prefer a different
implementation.

Thanks!
