### PR TITLE
Fix renovate config & gitignore

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
       "matchManagers": ["gomod"],
       "groupName": "Gomod updates",
       "groupSlug": "gomod-updates"
-    }
+    },
     {
       "description": "Group all Helm updates",
       "matchManagers": ["helmv3", "helm-values", "helmfile"],

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,7 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+mixin/vendor
+
+# IDE specifics
+.idea/


### PR DESCRIPTION
Fixes both the gitignore and renovate config.

Gitignore now properly excludes vendored mixin files

Renovate config has a missing comma re-added