### PR TITLE
Fix: Fix renovate setup and disable lockFileMaintenance  

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,9 @@
   "minimumReleaseAge": "3 days",
   "prCreation": "not-pending",
   "updateNotScheduled": false,
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "description": "Group all Dockerfile updates",

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version-file: 'go mod'
+          go-version-file: 'go.mod'
 
       - name: Download Go modules
         run: go mod download


### PR DESCRIPTION
## What is this PR and why do we need it

Fixes a typo in `setup.yml`, which was causing Renovate errors on the workflow. Also adds `lockFileMaintenance: { enabled: false }` to the Renovate config to stop noisy refresh all locks PRs against `mixin/jsonnetfile.lock.json` (see #53).