### PR TITLE
Add Buildkite pipeline to build and push exporter image to ECR

### DIFF
--- a/.buildkite/build-push-ecr.sh
+++ b/.buildkite/build-push-ecr.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the snowflake-exporter binary (promu / make build), image (Dockerfile), and push to ECR.
+# ECR authentication is handled by the ecr Buildkite plugin in pipeline.yaml (login: true).
+
+set -euo pipefail
+
+VERSION="${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is not set}"
+
+ECR_HOST="${ECR_HOST:-460210468233.dkr.ecr.us-east-1.amazonaws.com}"
+REPO_NAME="${REPO_NAME:-snowflake-exporter/snowflake-prometheus-exporter}"
+IMAGE_DEST="${ECR_HOST}/${REPO_NAME}:${VERSION}"
+
+ANNOTATION_MSG="Building and pushing ${IMAGE_DEST}"
+echo "${ANNOTATION_MSG}"
+buildkite-agent annotate --style "info" "${ANNOTATION_MSG}" || true
+
+set -x
+
+GO_VER="1.25.0"
+if [ ! -x "go/bin/go" ]; then
+  echo "Installing Go ${GO_VER} into ./go ..."
+  curl -fsSL "https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz" | tar -xz
+fi
+export PATH="${PWD}/go/bin:${PATH}"
+export PATH="$(go env GOPATH)/bin:${PATH}"
+go version
+
+go mod download
+make build
+
+docker build -t "${IMAGE_DEST}" \
+  -f Dockerfile \
+  --build-arg ARCH=amd64 \
+  --build-arg OS=linux \
+  .
+
+docker push "${IMAGE_DEST}"
+
+buildkite-agent annotate --style "success" "Pushed ${IMAGE_DEST}" || true

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,25 @@
+steps:
+  - label: Build and push to ECR
+    key: "build-and-push-to-ecr"
+    branches: "main production"
+    commands:
+      - bash .buildkite/build-push-ecr.sh
+    timeout_in_minutes: 5
+    plugins:
+      - ecr#89b335a:
+          login: true
+          region: "us-east-1"
+          account-ids:
+            - 460210468233
+  # - label: Update the latest image tag/ sha in the k8s deployment in repo audit-events-api-ops
+  #   branches: "main"
+  #   command:
+  #     - .buildkite/updateimage.sh $BUILDKITE_COMMIT latest
+  #   depends_on: "build-and-push-to-ecr"
+  #   timeout_in_minutes: 5
+  # - label: Update the production image tag/sha in the k8s deployment in repo audit-events-api-ops
+  #   branches: "production"
+  #   command:
+  #     - .buildkite/updateimage.sh $BUILDKITE_COMMIT production
+  #   depends_on: "build-and-push-to-ecr"
+  #   timeout_in_minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ mixin/vendor
 
 # IDE specifics
 .idea/
+
+# Local SDLC / planning artifacts (keep out of commits and GitHub)
+.sdlc/


### PR DESCRIPTION
## Summary

Adds a Buildkite pipeline and script to build the snowflake-prometheus-exporter binary (via existing `make build` / promu), package it with the current Dockerfile, and push to ECR. Also ignores `.sdlc/` so local SDLC files are not committed or shown on GitHub.

## Changes

- **`.buildkite/pipeline.yaml`** — Step `build-and-push-to-ecr` on `main` and `production`; uses the `ecr` plugin for registry login (`us-east-1`, account `460210468233`); runs the shell script with a 5-minute timeout.
- **`.buildkite/build-push-ecr.sh`** — Installs Go 1.25.0 under `./go` if missing, runs `go mod download` and `make build`, then `docker build` / `docker push` to `ECR_HOST/REPO_NAME:$BUILDKITE_COMMIT` (defaults match the pipeline; overridable via `ECR_HOST` / `REPO_NAME`). Adds Buildkite annotations for start and success.
- **`.gitignore`** — Add `.sdlc/` for local-only SDLC artifacts.

## Notes

- Image name follows `snowflake-exporter/snowflake-prometheus-exporter` in ECR (not the Makefile’s `-linux-amd64` suffix); adjust `REPO_NAME` / `ECR_HOST` in Buildkite env if your ECR layout differs.
- Ensure the ECR repository exists and the Buildkite agent role can push to it.