### PR TITLE
fix: Snowflake mixin minor display issues

### DIFF
--- a/mixin/dashboards.libsonnet
+++ b/mixin/dashboards.libsonnet
@@ -27,6 +27,14 @@ local commonlib = import 'common-lib/common/main.libsonnet';
           )
         ) + root.applyCommon(
           vars.multiInstance + [
+            g.dashboard.variable.query.new(
+              'warehouse',
+            )
+            + g.dashboard.variable.custom.selectionOptions.withMulti(true)
+            + g.dashboard.variable.custom.selectionOptions.withIncludeAll(true)
+            + g.dashboard.variable.query.queryTypes.withLabelValues(label='warehouse', metric='snowflake_table_active_bytes{%(queriesSelector)s}' % vars)
+            + g.dashboard.variable.query.withDatasourceFromVariable(vars.datasources.prometheus)
+            + g.dashboard.variable.query.refresh.onTime(),
           ],
           uid + '_overview',
           tags,

--- a/mixin/dashboards_out/snowflake-data-ownership.json
+++ b/mixin/dashboards_out/snowflake-data-ownership.json
@@ -687,6 +687,7 @@
                   "uid": "${datasource}"
                },
                "includeAll": true,
+               "label": "Database",
                "multi": true,
                "name": "database_name",
                "query": "label_values(snowflake_table_active_bytes{job=\"integrations/snowflake\",job=~\"$job\",instance=~\"$instance\"}, database_name)",
@@ -699,6 +700,7 @@
                   "uid": "${datasource}"
                },
                "includeAll": true,
+               "label": "Schema",
                "multi": true,
                "name": "schema_name",
                "query": "label_values(snowflake_table_active_bytes{job=\"integrations/snowflake\",job=~\"$job\",instance=~\"$instance\", database_name=~\"$database_name\"}, schema_name)",

--- a/mixin/dashboards_out/snowflake-overview.json
+++ b/mixin/dashboards_out/snowflake-overview.json
@@ -1369,6 +1369,20 @@
                "refresh": 2,
                "sort": 1,
                "type": "query"
+            },
+            {
+               "allValue": ".*",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "includeAll": true,
+               "label": "Warehouse",
+               "multi": true,
+               "name": "warehouse",
+               "query": "label_values(snowflake_table_active_bytes{job=\"integrations/snowflake\",job=~\"$job\",instance=~\"$instance\"}, warehouse)",
+               "refresh": 2,
+               "type": "query"
             }
          ]
       },

--- a/mixin/mixin.libsonnet
+++ b/mixin/mixin.libsonnet
@@ -20,6 +20,12 @@ local optional_labels = {
   instance+: {
     label: 'Exporter instance',
   },
+  database_name+: {
+    label: 'Database',
+  },
+  schema_name+: {
+    label: 'Schema',
+  },
 };
 
 {


### PR DESCRIPTION
Identified a couple misses in further testing:

- label display values for `database_name` and `schema_name` should be `Database` and `Schema`
- Warehouse label which is currently hard set for some queries in the signals never had a selector so showed no data when it should have worked. 