### PR TITLE
Change test-mixin cache setup to always install dependencies

### DIFF
--- a/.github/workflows/test-mixin.yml
+++ b/.github/workflows/test-mixin.yml
@@ -26,15 +26,14 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.23
-      - name: Tools cache
-        id: tools-cache
+      - name: Package cache
+        id: package-cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/go/bin
           key: ${{ runner.os }}-tools-${{ hashFiles('Makefile') }}
       - name: Install CI dependencies
-        if: steps.tools-cache.outputs.cache-hit != 'true'
         run: make install-ci-deps
 
   lint-mixin:


### PR DESCRIPTION
Current setup is flaky due to if statement where go packages are cached but tools are not, leading to tool dependencies not being installed if a cache hit is made