### PR TITLE
feat: Add TASK_HISTORY collector for task execution metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # snowflake-prometheus-exporter
 
-Exports [Snowflake](www.snowflake.com) warehouse, database, table, and replication statistics for a Snowflake account via HTTP for Prometheus consumption.
+Exports [Snowflake](www.snowflake.com) warehouse, database, table, task, and replication statistics for a Snowflake account via HTTP for Prometheus consumption.
 
 ## Configuration
 
@@ -20,6 +20,7 @@ The exporter may be configured through its command line flags:
       --role="ACCOUNTADMIN"           The role to use when querying metrics.
       --warehouse=WAREHOUSE           The warehouse to use when querying metrics.
       --exclude-deleted-tables        Exclude deleted tables when collecting table storage metrics.
+      --exclude-task-history          Exclude task execution metrics collected from TASK_HISTORY.
       --enable-tracing                Enable trace logging for Snowflake connections.
       --version                       Show application version.
       --log.level=info                Only log messages with the given severity or above. One of: [debug, info, warn, error]
@@ -54,6 +55,7 @@ Alternatively, the exporter may be configured using environment variables:
 | SNOWFLAKE_EXPORTER_ROLE                 | The role to use when querying metrics.                                           |
 | SNOWFLAKE_EXPORTER_WAREHOUSE            | The warehouse to use when querying metrics.                                      |
 | SNOWFLAKE_EXPORTER_ENABLE_TRACING       | Enable trace logging for Snowflake connections.                                  |
+| SNOWFLAKE_EXPORTER_EXCLUDE_TASK_HISTORY | Exclude task execution metrics collected from TASK_HISTORY.                      |
 | SNOWFLAKE_EXPORTER_WEB_TELEMETRY_PATH   | Path under which to expose metrics.                                              |
 
 Example usage:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The exporter may be configured through its command line flags:
       --role="ACCOUNTADMIN"           The role to use when querying metrics.
       --warehouse=WAREHOUSE           The warehouse to use when querying metrics.
       --exclude-deleted-tables        Exclude deleted tables when collecting table storage metrics.
-      --exclude-task-history          Exclude task execution metrics collected from TASK_HISTORY.
+      --enable-task-history           Collect task execution metrics from TASK_HISTORY. Disabled by default.
       --enable-tracing                Enable trace logging for Snowflake connections.
       --version                       Show application version.
       --log.level=info                Only log messages with the given severity or above. One of: [debug, info, warn, error]
@@ -55,7 +55,7 @@ Alternatively, the exporter may be configured using environment variables:
 | SNOWFLAKE_EXPORTER_ROLE                 | The role to use when querying metrics.                                           |
 | SNOWFLAKE_EXPORTER_WAREHOUSE            | The warehouse to use when querying metrics.                                      |
 | SNOWFLAKE_EXPORTER_ENABLE_TRACING       | Enable trace logging for Snowflake connections.                                  |
-| SNOWFLAKE_EXPORTER_EXCLUDE_TASK_HISTORY | Exclude task execution metrics collected from TASK_HISTORY.                      |
+| SNOWFLAKE_EXPORTER_ENABLE_TASK_HISTORY  | Collect task execution metrics from TASK_HISTORY. Disabled by default.           |
 | SNOWFLAKE_EXPORTER_WEB_TELEMETRY_PATH   | Path under which to expose metrics.                                              |
 
 Example usage:

--- a/cmd/snowflake-exporter/main.go
+++ b/cmd/snowflake-exporter/main.go
@@ -44,7 +44,7 @@ var (
 	role               = kingpin.Flag("role", "The role to use when querying metrics.").Default("ACCOUNTADMIN").Envar("SNOWFLAKE_EXPORTER_ROLE").String()
 	warehouse          = kingpin.Flag("warehouse", "The warehouse to use when querying metrics.").Envar("SNOWFLAKE_EXPORTER_WAREHOUSE").Required().String()
 	excludeDeleted     = kingpin.Flag("exclude-deleted-tables", "Exclude deleted tables when collecting table storage metrics.").Default("false").Bool()
-	excludeTaskHistory = kingpin.Flag("exclude-task-history", "Exclude task execution metrics collected from TASK_HISTORY.").Default("false").Envar("SNOWFLAKE_EXPORTER_EXCLUDE_TASK_HISTORY").Bool()
+	enableTaskHistory  = kingpin.Flag("enable-task-history", "Collect task execution metrics from TASK_HISTORY. Disabled by default since it's a new query family and not every account runs tasks.").Default("false").Envar("SNOWFLAKE_EXPORTER_ENABLE_TASK_HISTORY").Bool()
 	enableTracing      = kingpin.Flag("enable-tracing", "Enable trace logging for Snowflake connections.").Default("false").Envar("SNOWFLAKE_EXPORTER_ENABLE_TRACING").Bool()
 )
 
@@ -80,7 +80,7 @@ func main() {
 		Role:               *role,
 		Warehouse:          *warehouse,
 		ExcludeDeleted:     *excludeDeleted,
-		ExcludeTaskHistory: *excludeTaskHistory,
+		EnableTaskHistory:  *enableTaskHistory,
 		EnableTracing:      *enableTracing,
 	}
 

--- a/cmd/snowflake-exporter/main.go
+++ b/cmd/snowflake-exporter/main.go
@@ -44,6 +44,7 @@ var (
 	role               = kingpin.Flag("role", "The role to use when querying metrics.").Default("ACCOUNTADMIN").Envar("SNOWFLAKE_EXPORTER_ROLE").String()
 	warehouse          = kingpin.Flag("warehouse", "The warehouse to use when querying metrics.").Envar("SNOWFLAKE_EXPORTER_WAREHOUSE").Required().String()
 	excludeDeleted     = kingpin.Flag("exclude-deleted-tables", "Exclude deleted tables when collecting table storage metrics.").Default("false").Bool()
+	excludeTaskHistory = kingpin.Flag("exclude-task-history", "Exclude task execution metrics collected from TASK_HISTORY.").Default("false").Envar("SNOWFLAKE_EXPORTER_EXCLUDE_TASK_HISTORY").Bool()
 	enableTracing      = kingpin.Flag("enable-tracing", "Enable trace logging for Snowflake connections.").Default("false").Envar("SNOWFLAKE_EXPORTER_ENABLE_TRACING").Bool()
 )
 
@@ -79,6 +80,7 @@ func main() {
 		Role:               *role,
 		Warehouse:          *warehouse,
 		ExcludeDeleted:     *excludeDeleted,
+		ExcludeTaskHistory: *excludeTaskHistory,
 		EnableTracing:      *enableTracing,
 	}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -865,7 +865,10 @@ func (c *Collector) collectTaskLastCompletedMetrics(db *sql.DB, metrics chan<- p
 			// destination is a string, so parsing it back here keeps this collector driver-agnostic.
 			t, err := time.Parse(time.RFC3339Nano, lastCompleted.String)
 			if err != nil {
-				return fmt.Errorf("failed to parse task last-completed time: %w", err)
+				// Skip just this task rather than aborting the loop and dropping every
+				// other task's last-completed metric over one bad timestamp.
+				c.logger.Warn("Failed to parse task last-completed time, skipping.", "task", name.String, "err", err)
+				continue
 			}
 			metrics <- prometheus.MustNewConstMetric(c.taskLastCompletedTimestampSeconds, prometheus.GaugeValue,
 				float64(t.Unix()), name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -88,6 +88,9 @@ type Collector struct {
 	taskSucceededRate                 *prometheus.Desc
 	taskFailedRate                    *prometheus.Desc
 	taskSkippedRate                   *prometheus.Desc
+	taskCancelledRate                 *prometheus.Desc
+	taskFailedAndAutoSuspendedRate    *prometheus.Desc
+	taskSuspendedRate                 *prometheus.Desc
 	taskLastCompletedTimestampSeconds *prometheus.Desc
 	up                                *prometheus.Desc
 }
@@ -279,6 +282,24 @@ func NewCollector(logger *slog.Logger, c *Config) *Collector {
 			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
 			nil,
 		),
+		taskCancelledRate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "cancelled_rate"),
+			"Rate of cancelled task executions per-hour over the last 24 hours.",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
+		taskFailedAndAutoSuspendedRate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "failed_and_auto_suspended_rate"),
+			"Rate of task executions per-hour over the last 24 hours that failed and caused the task to be automatically suspended.",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
+		taskSuspendedRate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "suspended_rate"),
+			"Rate of task executions per-hour over the last 24 hours that were suspended, e.g. due to a concurrent run limit.",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
 		taskLastCompletedTimestampSeconds: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "task", "last_completed_timestamp_seconds"),
 			"Unix timestamp of the most recent completed (succeeded or failed) execution of the task, looking back 7 days.",
@@ -328,6 +349,9 @@ func (c *Collector) Describe(descs chan<- *prometheus.Desc) {
 	descs <- c.taskSucceededRate
 	descs <- c.taskFailedRate
 	descs <- c.taskSkippedRate
+	descs <- c.taskCancelledRate
+	descs <- c.taskFailedAndAutoSuspendedRate
+	descs <- c.taskSuspendedRate
 	descs <- c.taskLastCompletedTimestampSeconds
 	descs <- c.up
 }
@@ -815,9 +839,9 @@ func (c *Collector) collectTaskHistoryMetrics(db *sql.DB, metrics chan<- prometh
 
 	for rows.Next() {
 		var name, databaseName, databaseID, schemaName, schemaID sql.NullString
-		var succeeded, failed, skipped, total sql.NullFloat64
+		var succeeded, failed, skipped, cancelled, failedAndAutoSuspended, suspended, total sql.NullFloat64
 		if err := rows.Scan(&name, &databaseName, &databaseID, &schemaName, &schemaID,
-			&succeeded, &failed, &skipped, &total); err != nil {
+			&succeeded, &failed, &skipped, &cancelled, &failedAndAutoSuspended, &suspended, &total); err != nil {
 			return fmt.Errorf("failed to scan row: %w", err)
 		}
 
@@ -836,6 +860,18 @@ func (c *Collector) collectTaskHistoryMetrics(db *sql.DB, metrics chan<- prometh
 		}
 		if skipped.Valid {
 			metrics <- prometheus.MustNewConstMetric(c.taskSkippedRate, prometheus.GaugeValue, skipped.Float64/24,
+				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+		if cancelled.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.taskCancelledRate, prometheus.GaugeValue, cancelled.Float64/24,
+				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+		if failedAndAutoSuspended.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.taskFailedAndAutoSuspendedRate, prometheus.GaugeValue, failedAndAutoSuspended.Float64/24,
+				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+		if suspended.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.taskSuspendedRate, prometheus.GaugeValue, suspended.Float64/24,
 				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
 		}
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -451,7 +451,10 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		wg.Done()
 	}()
 
-	if !c.config.ExcludeTaskHistory {
+	// Opt-in, unlike the exclude-* flags: this is a brand new query family, so
+	// existing deployments shouldn't get an extra TASK_HISTORY scan against
+	// their warehouse just from upgrading.
+	if c.config.EnableTaskHistory {
 		wg.Add(1)
 		go func() {
 			if err := c.collectTaskHistoryMetrics(db, metrics); err != nil {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	_ "github.com/snowflakedb/gosnowflake/v2" // Import the snowflake DB driver
@@ -83,6 +84,11 @@ type Collector struct {
 	tableDeletedTables                *prometheus.Desc
 	replicationUsedCredits            *prometheus.Desc
 	replicationTransferredBytes       *prometheus.Desc
+	taskExecutedRate                  *prometheus.Desc
+	taskSucceededRate                 *prometheus.Desc
+	taskFailedRate                    *prometheus.Desc
+	taskSkippedRate                   *prometheus.Desc
+	taskLastCompletedTimestampSeconds *prometheus.Desc
 	up                                *prometheus.Desc
 }
 
@@ -249,6 +255,36 @@ func NewCollector(logger *slog.Logger, c *Config) *Collector {
 			[]string{labelDatabaseName, labelDatabaseID},
 			nil,
 		),
+		taskExecutedRate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "executed_rate"),
+			"Rate of task executions per-hour over the last 24 hours (all terminal states except SCHEDULED).",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
+		taskSucceededRate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "succeeded_rate"),
+			"Rate of successful task executions per-hour over the last 24 hours.",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
+		taskFailedRate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "failed_rate"),
+			"Rate of failed task executions per-hour over the last 24 hours.",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
+		taskSkippedRate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "skipped_rate"),
+			"Rate of skipped task executions per-hour over the last 24 hours.",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
+		taskLastCompletedTimestampSeconds: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "task", "last_completed_timestamp_seconds"),
+			"Unix timestamp of the most recent completed (succeeded or failed) execution of the task, looking back 7 days.",
+			[]string{labelName, labelDatabaseName, labelDatabaseID, labelSchemaName, labelSchemaID},
+			nil,
+		),
 		up: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "up"),
 			"Metric indicating the status of the exporter collection. 1 indicates that the connection Snowflake was successful, and all available metrics were collected. "+
@@ -288,6 +324,11 @@ func (c *Collector) Describe(descs chan<- *prometheus.Desc) {
 	descs <- c.tableDeletedTables
 	descs <- c.replicationUsedCredits
 	descs <- c.replicationTransferredBytes
+	descs <- c.taskExecutedRate
+	descs <- c.taskSucceededRate
+	descs <- c.taskFailedRate
+	descs <- c.taskSkippedRate
+	descs <- c.taskLastCompletedTimestampSeconds
 	descs <- c.up
 }
 
@@ -409,6 +450,26 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		}
 		wg.Done()
 	}()
+
+	if !c.config.ExcludeTaskHistory {
+		wg.Add(1)
+		go func() {
+			if err := c.collectTaskHistoryMetrics(db, metrics); err != nil {
+				c.logger.Error("Failed to collect task history metrics.", "err", err)
+				up.Store(false)
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			if err := c.collectTaskLastCompletedMetrics(db, metrics); err != nil {
+				c.logger.Error("Failed to collect task last-completed metrics.", "err", err)
+				up.Store(false)
+			}
+			wg.Done()
+		}()
+	}
 
 	wg.Wait()
 	upValue := 0.0
@@ -737,5 +798,77 @@ func (c *Collector) collectReplicationMetrics(db *sql.DB, metrics chan<- prometh
 	}
 
 	c.logger.Debug("Finished collecting replication metrics.")
+	return rows.Err()
+}
+
+func (c *Collector) collectTaskHistoryMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	c.logger.Debug("Collecting task history metrics.")
+	rows, err := db.Query(taskHistoryMetricQuery)
+	c.logger.Debug("Done querying task history metrics.")
+	if err != nil {
+		return fmt.Errorf("failed to query metrics: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var name, databaseName, databaseID, schemaName, schemaID sql.NullString
+		var succeeded, failed, skipped, total sql.NullFloat64
+		if err := rows.Scan(&name, &databaseName, &databaseID, &schemaName, &schemaID,
+			&succeeded, &failed, &skipped, &total); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		// Divided by 24 to get the per-hour average, consistent with the login rate metrics above.
+		if total.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.taskExecutedRate, prometheus.GaugeValue, total.Float64/24,
+				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+		if succeeded.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.taskSucceededRate, prometheus.GaugeValue, succeeded.Float64/24,
+				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+		if failed.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.taskFailedRate, prometheus.GaugeValue, failed.Float64/24,
+				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+		if skipped.Valid {
+			metrics <- prometheus.MustNewConstMetric(c.taskSkippedRate, prometheus.GaugeValue, skipped.Float64/24,
+				name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+	}
+
+	c.logger.Debug("Finished collecting task history metrics.")
+	return rows.Err()
+}
+
+func (c *Collector) collectTaskLastCompletedMetrics(db *sql.DB, metrics chan<- prometheus.Metric) error {
+	c.logger.Debug("Collecting task last-completed metrics.")
+	rows, err := db.Query(taskLastCompletedMetricQuery)
+	c.logger.Debug("Done querying task last-completed metrics.")
+	if err != nil {
+		return fmt.Errorf("failed to query metrics: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var name, databaseName, databaseID, schemaName, schemaID, lastCompleted sql.NullString
+		if err := rows.Scan(&name, &databaseName, &databaseID, &schemaName, &schemaID, &lastCompleted); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if lastCompleted.Valid {
+			// Scanned as a string rather than sql.NullTime: gosnowflake returns TIMESTAMP_LTZ
+			// columns as time.Time, which database/sql formats to RFC3339Nano when the scan
+			// destination is a string, so parsing it back here keeps this collector driver-agnostic.
+			t, err := time.Parse(time.RFC3339Nano, lastCompleted.String)
+			if err != nil {
+				return fmt.Errorf("failed to parse task last-completed time: %w", err)
+			}
+			metrics <- prometheus.MustNewConstMetric(c.taskLastCompletedTimestampSeconds, prometheus.GaugeValue,
+				float64(t.Unix()), name.String, databaseName.String, databaseID.String, schemaName.String, schemaID.String)
+		}
+	}
+
+	c.logger.Debug("Finished collecting task last-completed metrics.")
 	return rows.Err()
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -32,16 +32,17 @@ import (
 )
 
 var ExampleConfig = &Config{
-	AccountName: "defaultaccount",
-	Username:    "defaultuser",
-	Password:    "defaultpassword",
-	Warehouse:   "defaultwarehouse",
-	Role:        "ACCOUNTADMIN",
+	AccountName:       "defaultaccount",
+	Username:          "defaultuser",
+	Password:          "defaultpassword",
+	Warehouse:         "defaultwarehouse",
+	Role:              "ACCOUNTADMIN",
+	EnableTaskHistory: true,
 }
 
 func TestCollector_Collect(t *testing.T) {
 	t.Run("Metrics match expected", func(t *testing.T) {
-		db, mock := createMockDB(t)
+		db, mock := createMockDB(t, true)
 		mock.MatchExpectationsInOrder(false)
 
 		col := NewCollector(promslog.NewNopLogger(), ExampleConfig)
@@ -57,7 +58,7 @@ func TestCollector_Collect(t *testing.T) {
 	})
 
 	t.Run("Metrics have no lint errors", func(t *testing.T) {
-		db, mock := createMockDB(t)
+		db, mock := createMockDB(t, true)
 		mock.MatchExpectationsInOrder(false)
 
 		col := NewCollector(promslog.NewNopLogger(), ExampleConfig)
@@ -71,7 +72,7 @@ func TestCollector_Collect(t *testing.T) {
 	})
 
 	t.Run("All queries fail", func(t *testing.T) {
-		db, mock := createQueryErrMockDB(t)
+		db, mock := createQueryErrMockDB(t, true)
 		mock.MatchExpectationsInOrder(false)
 
 		col := NewCollector(promslog.NewNopLogger(), ExampleConfig)
@@ -103,6 +104,37 @@ func TestCollector_Collect(t *testing.T) {
 		// No metrics should be scraped if the database fails to open
 		err = testutil.CollectAndCompare(col, f)
 		require.NoError(t, err)
+	})
+
+	t.Run("Task history metrics are skipped when disabled", func(t *testing.T) {
+		// Deliberately does not register taskHistoryMetricQuery/taskLastCompletedMetricQuery
+		// with sqlmock: if the collector queried them anyway despite EnableTaskHistory being
+		// false, those calls would fail with "call to Query ... was not expected", which would
+		// surface as a scan/query error rather than silently succeeding.
+		db, mock := createMockDB(t, false)
+		mock.MatchExpectationsInOrder(false)
+
+		configWithoutTaskHistory := &Config{
+			AccountName: "defaultaccount",
+			Username:    "defaultuser",
+			Password:    "defaultpassword",
+			Warehouse:   "defaultwarehouse",
+			Role:        "ACCOUNTADMIN",
+		}
+		col := NewCollector(promslog.NewNopLogger(), configWithoutTaskHistory)
+		col.openDatabase = func(_ string) (*sql.DB, error) { return db, nil }
+
+		reg := prometheus.NewPedanticRegistry()
+		require.NoError(t, reg.Register(col))
+
+		families, err := reg.Gather()
+		require.NoError(t, err)
+
+		for _, f := range families {
+			require.NotContains(t, f.GetName(), "task", "task metrics should not be collected when EnableTaskHistory is false")
+		}
+
+		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }
 
@@ -207,7 +239,7 @@ func newRows(t *testing.T, rows [][]*string) *sqlmock.Rows {
 	return sqlRows
 }
 
-func createMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+func createMockDB(t *testing.T, enableTaskHistory bool) (*sql.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
 	testDB1Name := "mock_db"
@@ -376,38 +408,40 @@ func createMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 		).
 		RowsWillBeClosed()
 
-	testTaskName := "mock_task"
+	if enableTaskHistory {
+		testTaskName := "mock_task"
 
-	mock.ExpectQuery(taskHistoryMetricQuery).
-		WillReturnRows(
-			newRows(t, [][]*string{
-				{
-					&testTaskName, &testDB1Name, &testDB1ID, &testSchemaName, &testSchemaID,
-					&val18, &val19, &val17, &val20,
-				},
-			}),
-		).
-		RowsWillBeClosed()
+		mock.ExpectQuery(taskHistoryMetricQuery).
+			WillReturnRows(
+				newRows(t, [][]*string{
+					{
+						&testTaskName, &testDB1Name, &testDB1ID, &testSchemaName, &testSchemaID,
+						&val18, &val19, &val17, &val20,
+					},
+				}),
+			).
+			RowsWillBeClosed()
 
-	testLastCompleted := "2024-01-01T00:00:00Z"
+		testLastCompleted := "2024-01-01T00:00:00Z"
 
-	mock.ExpectQuery(taskLastCompletedMetricQuery).
-		WillReturnRows(
-			newRows(t, [][]*string{
-				{
-					&testTaskName, &testDB1Name, &testDB1ID, &testSchemaName, &testSchemaID,
-					&testLastCompleted,
-				},
-			}),
-		).
-		RowsWillBeClosed()
+		mock.ExpectQuery(taskLastCompletedMetricQuery).
+			WillReturnRows(
+				newRows(t, [][]*string{
+					{
+						&testTaskName, &testDB1Name, &testDB1ID, &testSchemaName, &testSchemaID,
+						&testLastCompleted,
+					},
+				}),
+			).
+			RowsWillBeClosed()
+	}
 
 	mock.ExpectClose()
 
 	return db, mock
 }
 
-func createQueryErrMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+func createQueryErrMockDB(t *testing.T, enableTaskHistory bool) (*sql.DB, sqlmock.Sqlmock) {
 	t.Helper()
 
 	queryErr := errors.New("the query failed for inexplicable reasons")
@@ -425,8 +459,10 @@ func createQueryErrMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 	mock.ExpectQuery(tableStorageMetricQuery).WillReturnError(queryErr)
 	mock.ExpectQuery(deletedTablesMetricQuery).WillReturnError(queryErr)
 	mock.ExpectQuery(replicationMetricQuery).WillReturnError(queryErr)
-	mock.ExpectQuery(taskHistoryMetricQuery).WillReturnError(queryErr)
-	mock.ExpectQuery(taskLastCompletedMetricQuery).WillReturnError(queryErr)
+	if enableTaskHistory {
+		mock.ExpectQuery(taskHistoryMetricQuery).WillReturnError(queryErr)
+		mock.ExpectQuery(taskLastCompletedMetricQuery).WillReturnError(queryErr)
+	}
 
 	mock.ExpectClose()
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -416,13 +416,16 @@ func createMockDB(t *testing.T, enableTaskHistory bool) (*sql.DB, sqlmock.Sqlmoc
 
 	if enableTaskHistory {
 		testTaskName := "mock_task"
+		val30 := "2"
+		val31 := "1"
+		val32 := "3"
 
 		mock.ExpectQuery(taskHistoryMetricQuery).
 			WillReturnRows(
 				newRows(t, [][]*string{
 					{
 						&testTaskName, &testDB1Name, &testDB1ID, &testSchemaName, &testSchemaID,
-						&val18, &val19, &val17, &val20,
+						&val18, &val19, &val17, &val30, &val31, &val32, &val20,
 					},
 				}),
 			).

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -376,6 +376,32 @@ func createMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 		).
 		RowsWillBeClosed()
 
+	testTaskName := "mock_task"
+
+	mock.ExpectQuery(taskHistoryMetricQuery).
+		WillReturnRows(
+			newRows(t, [][]*string{
+				{
+					&testTaskName, &testDB1Name, &testDB1ID, &testSchemaName, &testSchemaID,
+					&val18, &val19, &val17, &val20,
+				},
+			}),
+		).
+		RowsWillBeClosed()
+
+	testLastCompleted := "2024-01-01T00:00:00Z"
+
+	mock.ExpectQuery(taskLastCompletedMetricQuery).
+		WillReturnRows(
+			newRows(t, [][]*string{
+				{
+					&testTaskName, &testDB1Name, &testDB1ID, &testSchemaName, &testSchemaID,
+					&testLastCompleted,
+				},
+			}),
+		).
+		RowsWillBeClosed()
+
 	mock.ExpectClose()
 
 	return db, mock
@@ -399,6 +425,8 @@ func createQueryErrMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 	mock.ExpectQuery(tableStorageMetricQuery).WillReturnError(queryErr)
 	mock.ExpectQuery(deletedTablesMetricQuery).WillReturnError(queryErr)
 	mock.ExpectQuery(replicationMetricQuery).WillReturnError(queryErr)
+	mock.ExpectQuery(taskHistoryMetricQuery).WillReturnError(queryErr)
+	mock.ExpectQuery(taskLastCompletedMetricQuery).WillReturnError(queryErr)
 
 	mock.ExpectClose()
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -108,9 +108,8 @@ func TestCollector_Collect(t *testing.T) {
 
 	t.Run("Task history metrics are skipped when disabled", func(t *testing.T) {
 		// Deliberately does not register taskHistoryMetricQuery/taskLastCompletedMetricQuery
-		// with sqlmock: if the collector queried them anyway despite EnableTaskHistory being
-		// false, those calls would fail with "call to Query ... was not expected", which would
-		// surface as a scan/query error rather than silently succeeding.
+		// with sqlmock, so that if EnableTaskHistory being false failed to gate them, the
+		// collector would see those two queries fail and snowflake_up would drop to 0.
 		db, mock := createMockDB(t, false)
 		mock.MatchExpectationsInOrder(false)
 
@@ -130,9 +129,16 @@ func TestCollector_Collect(t *testing.T) {
 		families, err := reg.Gather()
 		require.NoError(t, err)
 
+		var sawUp bool
 		for _, f := range families {
 			require.NotContains(t, f.GetName(), "task", "task metrics should not be collected when EnableTaskHistory is false")
+			if f.GetName() == "snowflake_up" {
+				sawUp = true
+				require.Equal(t, float64(1), f.GetMetric()[0].GetGauge().GetValue(),
+					"snowflake_up should be 1; if it's 0, the task queries were probably issued despite being disabled")
+			}
 		}
+		require.True(t, sawUp, "expected a snowflake_up metric family")
 
 		require.NoError(t, mock.ExpectationsWereMet())
 	})

--- a/collector/config.go
+++ b/collector/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	PrivateKeyPassword string
 	PrivateKey         *rsa.PrivateKey
 	ExcludeDeleted     bool
+	ExcludeTaskHistory bool
 	EnableTracing      bool
 }
 

--- a/collector/config.go
+++ b/collector/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	PrivateKeyPassword string
 	PrivateKey         *rsa.PrivateKey
 	ExcludeDeleted     bool
-	ExcludeTaskHistory bool
+	EnableTaskHistory  bool
 	EnableTracing      bool
 }
 

--- a/collector/query.go
+++ b/collector/query.go
@@ -86,7 +86,9 @@ const (
 	// ACCOUNT_USAGE views queried above; its database/schema id columns are prefixed
 	// with TASK_ instead.
 	taskHistoryMetricQuery = `SELECT NAME, DATABASE_NAME, TASK_DATABASE_ID, SCHEMA_NAME, TASK_SCHEMA_ID,
-		sum(iff(STATE = 'SUCCEEDED', 1, 0)), sum(iff(STATE = 'FAILED', 1, 0)), sum(iff(STATE = 'SKIPPED', 1, 0)), count(*)
+		sum(iff(STATE = 'SUCCEEDED', 1, 0)), sum(iff(STATE = 'FAILED', 1, 0)), sum(iff(STATE = 'SKIPPED', 1, 0)),
+		sum(iff(STATE = 'CANCELLED', 1, 0)), sum(iff(STATE = 'FAILED_AND_AUTO_SUSPENDED', 1, 0)), sum(iff(STATE = 'SUSPENDED', 1, 0)),
+		count(*)
 	FROM ACCOUNT_USAGE.TASK_HISTORY
 	WHERE SCHEDULED_TIME >= dateadd(hour, -24, current_timestamp()) AND STATE != 'SCHEDULED'
 	GROUP BY NAME, DATABASE_NAME, TASK_DATABASE_ID, SCHEMA_NAME, TASK_SCHEMA_ID;`

--- a/collector/query.go
+++ b/collector/query.go
@@ -82,19 +82,22 @@ const (
 	GROUP BY DATABASE_NAME, DATABASE_ID;`
 
 	// https://docs.snowflake.com/en/sql-reference/account-usage/task_history.html
-	taskHistoryMetricQuery = `SELECT NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID,
+	// TASK_HISTORY does not follow the DATABASE_ID/SCHEMA_ID naming used by the other
+	// ACCOUNT_USAGE views queried above; its database/schema id columns are prefixed
+	// with TASK_ instead.
+	taskHistoryMetricQuery = `SELECT NAME, DATABASE_NAME, TASK_DATABASE_ID, SCHEMA_NAME, TASK_SCHEMA_ID,
 		sum(iff(STATE = 'SUCCEEDED', 1, 0)), sum(iff(STATE = 'FAILED', 1, 0)), sum(iff(STATE = 'SKIPPED', 1, 0)), count(*)
 	FROM ACCOUNT_USAGE.TASK_HISTORY
 	WHERE SCHEDULED_TIME >= dateadd(hour, -24, current_timestamp()) AND STATE != 'SCHEDULED'
-	GROUP BY NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID;`
+	GROUP BY NAME, DATABASE_NAME, TASK_DATABASE_ID, SCHEMA_NAME, TASK_SCHEMA_ID;`
 
 	// https://docs.snowflake.com/en/sql-reference/account-usage/task_history.html
 	// Looks back further than the rate query above so that infrequently-scheduled
 	// tasks (e.g. daily/weekly) still report a last-completed time instead of
 	// going missing from this metric between runs.
-	taskLastCompletedMetricQuery = `SELECT NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID,
+	taskLastCompletedMetricQuery = `SELECT NAME, DATABASE_NAME, TASK_DATABASE_ID, SCHEMA_NAME, TASK_SCHEMA_ID,
 		max(COMPLETED_TIME)
 	FROM ACCOUNT_USAGE.TASK_HISTORY
 	WHERE SCHEDULED_TIME >= dateadd(day, -7, current_timestamp()) AND STATE IN ('SUCCEEDED', 'FAILED')
-	GROUP BY NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID;`
+	GROUP BY NAME, DATABASE_NAME, TASK_DATABASE_ID, SCHEMA_NAME, TASK_SCHEMA_ID;`
 )

--- a/collector/query.go
+++ b/collector/query.go
@@ -76,8 +76,25 @@ const (
 	WHERE DELETED = TRUE;`
 
 	// https://docs.snowflake.com/en/sql-reference/account-usage/replication_usage_history.html
-	replicationMetricQuery = `SELECT DATABASE_NAME, DATABASE_ID, sum(CREDITS_USED), sum(BYTES_TRANSFERRED) 
+	replicationMetricQuery = `SELECT DATABASE_NAME, DATABASE_ID, sum(CREDITS_USED), sum(BYTES_TRANSFERRED)
 	FROM ACCOUNT_USAGE.REPLICATION_USAGE_HISTORY
 	WHERE START_TIME >= dateadd(hour, -24, current_timestamp())
 	GROUP BY DATABASE_NAME, DATABASE_ID;`
+
+	// https://docs.snowflake.com/en/sql-reference/account-usage/task_history.html
+	taskHistoryMetricQuery = `SELECT NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID,
+		sum(iff(STATE = 'SUCCEEDED', 1, 0)), sum(iff(STATE = 'FAILED', 1, 0)), sum(iff(STATE = 'SKIPPED', 1, 0)), count(*)
+	FROM ACCOUNT_USAGE.TASK_HISTORY
+	WHERE SCHEDULED_TIME >= dateadd(hour, -24, current_timestamp()) AND STATE != 'SCHEDULED'
+	GROUP BY NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID;`
+
+	// https://docs.snowflake.com/en/sql-reference/account-usage/task_history.html
+	// Looks back further than the rate query above so that infrequently-scheduled
+	// tasks (e.g. daily/weekly) still report a last-completed time instead of
+	// going missing from this metric between runs.
+	taskLastCompletedMetricQuery = `SELECT NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID,
+		max(COMPLETED_TIME)
+	FROM ACCOUNT_USAGE.TASK_HISTORY
+	WHERE SCHEDULED_TIME >= dateadd(day, -7, current_timestamp()) AND STATE IN ('SUCCEEDED', 'FAILED')
+	GROUP BY NAME, DATABASE_NAME, DATABASE_ID, SCHEMA_NAME, SCHEMA_ID;`
 )

--- a/collector/testdata/all_metrics.prom
+++ b/collector/testdata/all_metrics.prom
@@ -63,6 +63,21 @@ snowflake_table_failsafe_bytes{database_id="2",database_name="another_mock_db",s
 # TYPE snowflake_table_time_travel_bytes gauge
 snowflake_table_time_travel_bytes{database_id="1",database_name="mock_db",schema_id="4",schema_name="mock_schema",table_id="3",table_name="mock_table"} 2048
 snowflake_table_time_travel_bytes{database_id="2",database_name="another_mock_db",schema_id="4",schema_name="",table_id="3",table_name="mock_table"} 32768
+# HELP snowflake_task_executed_rate Rate of task executions per-hour over the last 24 hours (all terminal states except SCHEDULED).
+# TYPE snowflake_task_executed_rate gauge
+snowflake_task_executed_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 51.416666666666664
+# HELP snowflake_task_failed_rate Rate of failed task executions per-hour over the last 24 hours.
+# TYPE snowflake_task_failed_rate gauge
+snowflake_task_failed_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 0.4166666666666667
+# HELP snowflake_task_last_completed_timestamp_seconds Unix timestamp of the most recent completed (succeeded or failed) execution of the task, looking back 7 days.
+# TYPE snowflake_task_last_completed_timestamp_seconds gauge
+snowflake_task_last_completed_timestamp_seconds{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 1.7040672e+09
+# HELP snowflake_task_skipped_rate Rate of skipped task executions per-hour over the last 24 hours.
+# TYPE snowflake_task_skipped_rate gauge
+snowflake_task_skipped_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 1.6666666666666667
+# HELP snowflake_task_succeeded_rate Rate of successful task executions per-hour over the last 24 hours.
+# TYPE snowflake_task_succeeded_rate gauge
+snowflake_task_succeeded_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 0.8333333333333334
 # HELP snowflake_table_deleted_tables Number of tables that have been purged from storage.
 # TYPE snowflake_table_deleted_tables gauge
 snowflake_table_deleted_tables 10

--- a/collector/testdata/all_metrics.prom
+++ b/collector/testdata/all_metrics.prom
@@ -63,9 +63,15 @@ snowflake_table_failsafe_bytes{database_id="2",database_name="another_mock_db",s
 # TYPE snowflake_table_time_travel_bytes gauge
 snowflake_table_time_travel_bytes{database_id="1",database_name="mock_db",schema_id="4",schema_name="mock_schema",table_id="3",table_name="mock_table"} 2048
 snowflake_table_time_travel_bytes{database_id="2",database_name="another_mock_db",schema_id="4",schema_name="",table_id="3",table_name="mock_table"} 32768
+# HELP snowflake_task_cancelled_rate Rate of cancelled task executions per-hour over the last 24 hours.
+# TYPE snowflake_task_cancelled_rate gauge
+snowflake_task_cancelled_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 0.08333333333333333
 # HELP snowflake_task_executed_rate Rate of task executions per-hour over the last 24 hours (all terminal states except SCHEDULED).
 # TYPE snowflake_task_executed_rate gauge
 snowflake_task_executed_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 51.416666666666664
+# HELP snowflake_task_failed_and_auto_suspended_rate Rate of task executions per-hour over the last 24 hours that failed and caused the task to be automatically suspended.
+# TYPE snowflake_task_failed_and_auto_suspended_rate gauge
+snowflake_task_failed_and_auto_suspended_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 0.041666666666666664
 # HELP snowflake_task_failed_rate Rate of failed task executions per-hour over the last 24 hours.
 # TYPE snowflake_task_failed_rate gauge
 snowflake_task_failed_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 0.4166666666666667
@@ -78,6 +84,9 @@ snowflake_task_skipped_rate{database_id="1",database_name="mock_db",name="mock_t
 # HELP snowflake_task_succeeded_rate Rate of successful task executions per-hour over the last 24 hours.
 # TYPE snowflake_task_succeeded_rate gauge
 snowflake_task_succeeded_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 0.8333333333333334
+# HELP snowflake_task_suspended_rate Rate of task executions per-hour over the last 24 hours that were suspended, e.g. due to a concurrent run limit.
+# TYPE snowflake_task_suspended_rate gauge
+snowflake_task_suspended_rate{database_id="1",database_name="mock_db",name="mock_task",schema_id="4",schema_name="mock_schema"} 0.125
 # HELP snowflake_table_deleted_tables Number of tables that have been purged from storage.
 # TYPE snowflake_table_deleted_tables gauge
 snowflake_table_deleted_tables 10


### PR DESCRIPTION
## Summary

Adds a collector for `SNOWFLAKE.ACCOUNT_USAGE.TASK_HISTORY`, exposing task execution health alongside the existing storage/warehouse/login/replication metrics:

- `snowflake_task_executed_rate`, `snowflake_task_succeeded_rate`, `snowflake_task_failed_rate`, `snowflake_task_skipped_rate`, `snowflake_task_cancelled_rate`, `snowflake_task_failed_and_auto_suspended_rate`, `snowflake_task_suspended_rate` — per-hour rates over the last 24 hours, labeled by `name`, `database_name`, `database_id`, `schema_name`, `schema_id`. Follows the same "divide 24h count by 24" convention already used for the login-rate metrics.
- `snowflake_task_last_completed_timestamp_seconds` — unix timestamp of the most recent completed (succeeded/failed) run per task, looking back 7 days so infrequently-scheduled tasks don't drop out of the metric between runs. Useful for staleness alerts (`time() - snowflake_task_last_completed_timestamp_seconds > threshold`).

Collection is **opt-in** via a new `--enable-task-history` flag / `SNOWFLAKE_EXPORTER_ENABLE_TASK_HISTORY` env var (default `false`). Unlike `--exclude-deleted-tables` (opt-out, since that query already existed), this is a brand new query family — defaulting it on would mean every existing deployment gets an extra `TASK_HISTORY` scan against their warehouse just from upgrading, without asking.

## Motivation

We use this exporter for Snowflake storage metrics today and wanted task execution monitoring (failure/staleness alerts in Grafana/Alertmanager) without adding a second exporter tool. `TASK_HISTORY` requires no extra grants beyond the `IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE` this exporter already needs.

## Test plan

- [x] `go test ./...` passes, including updated `testdata/all_metrics.prom` golden file and a test asserting the task queries are never issued when `--enable-task-history` is off
- [x] `go vet ./...` / `gofmt -l .` clean
- [x] README flags/env-var tables updated